### PR TITLE
asegurar endpoints de edición/borrado y ocultar botones en UI según permisos

### DIFF
--- a/WayFinder/angular/src/app/calificaciones/calificaciones.html
+++ b/WayFinder/angular/src/app/calificaciones/calificaciones.html
@@ -92,10 +92,10 @@
         <p class="mb-3 text-dark">{{ item.comentario }}</p>
         
         <div class="d-flex gap-2">
-          <button class="btn btn-sm btn-outline-info" (click)="editarMiCalificacion(item)">
+          <button *ngIf="puedeEditar(item)" class="btn btn-sm btn-outline-info" (click)="editarMiCalificacion(item)">
             <i class="bi bi-pencil"></i> Editar
           </button>
-          <button class="btn btn-sm btn-outline-danger" (click)="eliminarMiCalificacion(item.id!)">
+          <button *ngIf="puedeEliminar(item)" class="btn btn-sm btn-outline-danger" (click)="eliminarMiCalificacion(item.id!)">
             <i class="bi bi-trash"></i> Eliminar
           </button>
         </div>

--- a/WayFinder/angular/src/app/calificaciones/calificaciones.ts
+++ b/WayFinder/angular/src/app/calificaciones/calificaciones.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { CalificacionService } from 'src/app/proxy/calificacion/calificacion.service';
 import { CalificacionDto } from 'src/app/proxy/destinos-turisticos-dtos/models';
-import { ConfigStateService } from '@abp/ng.core';
+import { ConfigStateService, PermissionService } from '@abp/ng.core';
 import { DestinoTuristicoService } from 'src/app/proxy/destino-turisticos/destino-turistico.service';
 
 @Component({
@@ -18,10 +18,11 @@ export class CalificacionesComponent implements OnChanges {
   @Input() ciudad: any; 
 
   private calificacionService = inject(CalificacionService);
-  private configState = inject(ConfigStateService); // NUEVO: Inyectamos el estado general
+  private configState = inject(ConfigStateService); 
+  private permissionService = inject(PermissionService); // Inyectamos servicio de permisos de ABP
   private destinoTuristicoService = inject(DestinoTuristicoService);
 
-  currentUser = this.configState.getOne('currentUser'); // NUEVO: Obtenemos el usuario logueado
+  currentUser = this.configState.getOne('currentUser');
   miCalificacionPrevia: any = null;
   listaComentarios: CalificacionDto[] = [];
   promedio: number = 0;
@@ -50,7 +51,7 @@ export class CalificacionesComponent implements OnChanges {
 
       // NUEVO: Buscamos si en la lista hay un comentario que me pertenezca
       // Nota: Si tu DTO usa otro nombre en vez de 'creatorId' (ej: 'usuarioId'), cámbialo aquí
-      this.miCalificacionPrevia = this.listaComentarios.find(c => c.userId === this.currentUser.id);
+      // this.miCalificacionPrevia = this.listaComentarios.find(c => c.userId === this.currentUser.id);
     });
 
     this.calificacionService.getPromedio(this.destinoId).subscribe(promedio => {
@@ -176,5 +177,17 @@ guardarCalificacion() {
     } else {
       return 'bi-star text-secondary';
     }
+  }
+
+  // Validaciones de UI
+  puedeEditar(item: CalificacionDto): boolean {
+    return this.currentUser?.id === item.userId;
+  }
+
+  puedeEliminar(item: CalificacionDto): boolean {
+    // Es mi reseña, o tengo permiso global de administrador para borrarlas
+    const esMia = this.currentUser?.id === item.userId;
+    const esAdmin = this.permissionService.getGrantedPolicy('WayFinder.Calificaciones.Delete');
+    return esMia || esAdmin;
   }
 }

--- a/WayFinder/angular/src/app/proxy/calificacion/calificacion.service.ts
+++ b/WayFinder/angular/src/app/proxy/calificacion/calificacion.service.ts
@@ -1,7 +1,7 @@
 import { RestService, Rest } from '@abp/ng.core';
 import type { PagedAndSortedResultRequestDto, PagedResultDto } from '@abp/ng.core';
 import { Injectable } from '@angular/core';
-import type { CalificacionDto, CrearCalificacionDto } from '../destinos-turisticos-dtos/models';
+import type { ActualizarCalificacionDto, CalificacionDto, CrearCalificacionDto } from '../destinos-turisticos-dtos/models';
 
 @Injectable({
   providedIn: 'root',
@@ -60,7 +60,7 @@ export class CalificacionService {
     { apiName: this.apiName,...config });
   
 
-  update = (id: string, input: CrearCalificacionDto, config?: Partial<Rest.Config>) =>
+  update = (id: string, input: ActualizarCalificacionDto, config?: Partial<Rest.Config>) =>
     this.restService.request<any, CalificacionDto>({
       method: 'PUT',
       url: `/api/app/calificacion/${id}`,

--- a/WayFinder/angular/src/app/proxy/destinos-turisticos-dtos/eventos/index.ts
+++ b/WayFinder/angular/src/app/proxy/destinos-turisticos-dtos/eventos/index.ts
@@ -1,0 +1,1 @@
+export * from './models';

--- a/WayFinder/angular/src/app/proxy/destinos-turisticos-dtos/eventos/models.ts
+++ b/WayFinder/angular/src/app/proxy/destinos-turisticos-dtos/eventos/models.ts
@@ -1,0 +1,9 @@
+
+export interface EventoDto {
+  idExterno?: string;
+  nombre?: string;
+  urlTicket?: string;
+  fechaInicio?: string;
+  imagenUrl?: string;
+  lugar?: string;
+}

--- a/WayFinder/angular/src/app/proxy/destinos-turisticos-dtos/index.ts
+++ b/WayFinder/angular/src/app/proxy/destinos-turisticos-dtos/index.ts
@@ -1,3 +1,4 @@
+import * as Eventos from './eventos';
 import * as Perfiles from './perfiles';
 export * from './models';
-export { Perfiles };
+export { Eventos, Perfiles };

--- a/WayFinder/angular/src/app/proxy/destinos-turisticos-dtos/models.ts
+++ b/WayFinder/angular/src/app/proxy/destinos-turisticos-dtos/models.ts
@@ -1,4 +1,10 @@
 import type { AuditedEntityDto } from '@abp/ng.core';
+import type { EventoDto } from './eventos/models';
+
+export interface ActualizarCalificacionDto {
+  puntaje: number;
+  comentario?: string;
+}
 
 export interface BuscarCiudadRequestDto {
   nombreCiudad?: string;
@@ -56,6 +62,7 @@ export interface DetalleCiudadDto {
   coordenadas: CoordenadasDto;
   zonaHoraria?: string;
   elevacionMetros?: number;
+  eventos: EventoDto[];
 }
 
 export interface FiltrarCiudadesRequestDto {

--- a/WayFinder/angular/src/app/proxy/generate-proxy.json
+++ b/WayFinder/angular/src/app/proxy/generate-proxy.json
@@ -983,9 +983,9 @@
                     },
                     {
                       "name": "input",
-                      "typeAsString": "WayFinder.DestinosTuristicosDTOs.CrearCalificacionDto, WayFinder.Application.Contracts",
-                      "type": "WayFinder.DestinosTuristicosDTOs.CrearCalificacionDto",
-                      "typeSimple": "WayFinder.DestinosTuristicosDTOs.CrearCalificacionDto",
+                      "typeAsString": "WayFinder.DestinosTuristicosDTOs.ActualizarCalificacionDto, WayFinder.Application.Contracts",
+                      "type": "WayFinder.DestinosTuristicosDTOs.ActualizarCalificacionDto",
+                      "typeSimple": "WayFinder.DestinosTuristicosDTOs.ActualizarCalificacionDto",
                       "isOptional": false,
                       "defaultValue": null
                     }
@@ -1181,9 +1181,9 @@
                 },
                 {
                   "name": "input",
-                  "typeAsString": "WayFinder.DestinosTuristicosDTOs.CrearCalificacionDto, WayFinder.Application.Contracts",
-                  "type": "WayFinder.DestinosTuristicosDTOs.CrearCalificacionDto",
-                  "typeSimple": "WayFinder.DestinosTuristicosDTOs.CrearCalificacionDto",
+                  "typeAsString": "WayFinder.DestinosTuristicosDTOs.ActualizarCalificacionDto, WayFinder.Application.Contracts",
+                  "type": "WayFinder.DestinosTuristicosDTOs.ActualizarCalificacionDto",
+                  "typeSimple": "WayFinder.DestinosTuristicosDTOs.ActualizarCalificacionDto",
                   "isOptional": false,
                   "defaultValue": null
                 }
@@ -1205,8 +1205,8 @@
                   "nameOnMethod": "input",
                   "name": "input",
                   "jsonName": null,
-                  "type": "WayFinder.DestinosTuristicosDTOs.CrearCalificacionDto",
-                  "typeSimple": "WayFinder.DestinosTuristicosDTOs.CrearCalificacionDto",
+                  "type": "WayFinder.DestinosTuristicosDTOs.ActualizarCalificacionDto",
+                  "typeSimple": "WayFinder.DestinosTuristicosDTOs.ActualizarCalificacionDto",
                   "isOptional": false,
                   "defaultValue": null,
                   "constraintTypes": null,
@@ -1219,7 +1219,7 @@
                 "typeSimple": "WayFinder.DestinosTuristicosDTOs.CalificacionDto"
               },
               "allowAnonymous": false,
-              "implementFrom": "Volo.Abp.Application.Services.IUpdateAppService<WayFinder.DestinosTuristicosDTOs.CalificacionDto,System.Guid,WayFinder.DestinosTuristicosDTOs.CrearCalificacionDto>"
+              "implementFrom": "Volo.Abp.Application.Services.IUpdateAppService<WayFinder.DestinosTuristicosDTOs.CalificacionDto,System.Guid,WayFinder.DestinosTuristicosDTOs.ActualizarCalificacionDto>"
             },
             "GetAsyncById": {
               "uniqueName": "GetAsyncById",
@@ -11641,6 +11641,39 @@
       "genericArguments": null,
       "properties": null
     },
+    "WayFinder.DestinosTuristicosDTOs.ActualizarCalificacionDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "Puntaje",
+          "jsonName": null,
+          "type": "System.Int32",
+          "typeSimple": "number",
+          "isRequired": false,
+          "minLength": null,
+          "maxLength": null,
+          "minimum": "1",
+          "maximum": "5",
+          "regex": null
+        },
+        {
+          "name": "Comentario",
+          "jsonName": null,
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false,
+          "minLength": null,
+          "maxLength": null,
+          "minimum": null,
+          "maximum": null,
+          "regex": null
+        }
+      ]
+    },
     "WayFinder.DestinosTuristicosDTOs.BuscarCiudadRequestDto": {
       "baseType": null,
       "isEnum": false,
@@ -12112,6 +12145,99 @@
           "jsonName": null,
           "type": "System.Double?",
           "typeSimple": "number?",
+          "isRequired": false,
+          "minLength": null,
+          "maxLength": null,
+          "minimum": null,
+          "maximum": null,
+          "regex": null
+        },
+        {
+          "name": "Eventos",
+          "jsonName": null,
+          "type": "[WayFinder.DestinosTuristicosDTOs.Eventos.EventoDto]",
+          "typeSimple": "[WayFinder.DestinosTuristicosDTOs.Eventos.EventoDto]",
+          "isRequired": false,
+          "minLength": null,
+          "maxLength": null,
+          "minimum": null,
+          "maximum": null,
+          "regex": null
+        }
+      ]
+    },
+    "WayFinder.DestinosTuristicosDTOs.Eventos.EventoDto": {
+      "baseType": null,
+      "isEnum": false,
+      "enumNames": null,
+      "enumValues": null,
+      "genericArguments": null,
+      "properties": [
+        {
+          "name": "IdExterno",
+          "jsonName": null,
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false,
+          "minLength": null,
+          "maxLength": null,
+          "minimum": null,
+          "maximum": null,
+          "regex": null
+        },
+        {
+          "name": "Nombre",
+          "jsonName": null,
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false,
+          "minLength": null,
+          "maxLength": null,
+          "minimum": null,
+          "maximum": null,
+          "regex": null
+        },
+        {
+          "name": "UrlTicket",
+          "jsonName": null,
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false,
+          "minLength": null,
+          "maxLength": null,
+          "minimum": null,
+          "maximum": null,
+          "regex": null
+        },
+        {
+          "name": "FechaInicio",
+          "jsonName": null,
+          "type": "System.DateTime",
+          "typeSimple": "string",
+          "isRequired": false,
+          "minLength": null,
+          "maxLength": null,
+          "minimum": null,
+          "maximum": null,
+          "regex": null
+        },
+        {
+          "name": "ImagenUrl",
+          "jsonName": null,
+          "type": "System.String",
+          "typeSimple": "string",
+          "isRequired": false,
+          "minLength": null,
+          "maxLength": null,
+          "minimum": null,
+          "maximum": null,
+          "regex": null
+        },
+        {
+          "name": "Lugar",
+          "jsonName": null,
+          "type": "System.String",
+          "typeSimple": "string",
           "isRequired": false,
           "minLength": null,
           "maxLength": null,

--- a/WayFinder/src/WayFinder.Application.Contracts/DestinosTuristicosDTOs/Calificaciones/CalificacionDto.cs
+++ b/WayFinder/src/WayFinder.Application.Contracts/DestinosTuristicosDTOs/Calificaciones/CalificacionDto.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
@@ -30,5 +30,12 @@ namespace WayFinder.DestinosTuristicosDTOs
         public string? Comentario { get; set; }
         public Guid UserId { get; set; }
 
+    }
+
+    public class ActualizarCalificacionDto
+    {
+        [Range(1, 5)]
+        public int Puntaje { get; set; }
+        public string? Comentario { get; set; }
     }
 }

--- a/WayFinder/src/WayFinder.Application.Contracts/Permissions/WayFinderPermissionDefinitionProvider.cs
+++ b/WayFinder/src/WayFinder.Application.Contracts/Permissions/WayFinderPermissionDefinitionProvider.cs
@@ -11,6 +11,9 @@ public class WayFinderPermissionDefinitionProvider : PermissionDefinitionProvide
     {
         var myGroup = context.AddGroup(WayFinderPermissions.GroupName);
 
+        var calificacionesGroup = context.GetGroupOrNull(WayFinderPermissions.GroupName) ?? context.AddGroup(WayFinderPermissions.GroupName);
+        calificacionesGroup.AddPermission(WayFinderPermissions.DeleteCalificacion, L("Permission:DeleteCalificacion"));
+
         //Define your own permissions here. Example:
         //myGroup.AddPermission(WayFinderPermissions.MyPermission1, L("Permission:MyPermission1"));
     }

--- a/WayFinder/src/WayFinder.Application.Contracts/Permissions/WayFinderPermissions.cs
+++ b/WayFinder/src/WayFinder.Application.Contracts/Permissions/WayFinderPermissions.cs
@@ -3,9 +3,10 @@ namespace WayFinder.Permissions;
 public static class WayFinderPermissions
 {
     public const string GroupName = "WayFinder";
+    public const string DeleteCalificacion = GroupName + ".Calificaciones.Delete";
 
 
-    
+
     //Add your own permission names. Example:
     //public const string MyPermission1 = GroupName + ".MyPermission1";
 }

--- a/WayFinder/src/WayFinder.Application/Calificaciones/CalificacionAppService.cs
+++ b/WayFinder/src/WayFinder.Application/Calificaciones/CalificacionAppService.cs
@@ -1,5 +1,6 @@
-﻿using AutoMapper;
+using AutoMapper;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,12 +9,12 @@ using Volo.Abp;
 using Volo.Abp.Application.Dtos;
 using Volo.Abp.Application.Services;
 using Volo.Abp.Authorization;
+using Volo.Abp.Data;
 using Volo.Abp.Domain.Repositories;
 using Volo.Abp.Users;
 using WayFinder.Calificaciones;
 using WayFinder.DestinosTuristicosDTOs;
-using Volo.Abp.Data;
-using Microsoft.EntityFrameworkCore;
+using WayFinder.Permissions;
 
 namespace WayFinder.Calificacion
 {
@@ -24,7 +25,8 @@ namespace WayFinder.Calificacion
         DestinosTuristicosDTOs.CalificacionDto,
         Guid,
         PagedAndSortedResultRequestDto,
-        CrearCalificacionDto>, ICalificacionAppService
+        CrearCalificacionDto,
+        ActualizarCalificacionDto>, ICalificacionAppService
 
 
         {
@@ -52,18 +54,35 @@ namespace WayFinder.Calificacion
                 await Repository.InsertAsync(entity, autoSave:true);
                 return ObjectMapper.Map<WayFinder.Calificaciones.Calificacion, CalificacionDto>(entity);
             }
-        // --- REQ 5.3: ELIMINAR CALIFICACIÓN PROPIA ---
+        // --- REQ 5.3: ELIMINAR CALIFICACIÓN PROPIA (Y ADMIN) ---
         public override async Task DeleteAsync(Guid id)
         {
-            var entity = await Repository.GetAsync(id);
+            // Primero intentamos buscar la entidad normalmente. Esto funcionará perfectamente para el autor.
+            var entity = await Repository.FindAsync(id);
 
-            // Validamos que el usuario logueado sea el dueño de la calificación
-            if (entity.UserId != _currentUser.GetId())
+            // Si es nula, podría ser porque somos Administrador y el filtro de EF Core la está ocultando.
+            if (entity == null)
             {
-                throw new AbpAuthorizationException("Solo puedes eliminar tus propias calificaciones.");
+                var query = await Repository.GetQueryableAsync();
+                entity = await query.IgnoreQueryFilters().FirstOrDefaultAsync(c => c.Id == id);
             }
 
-            await base.DeleteAsync(id);
+            if (entity == null)
+            {
+                throw new Volo.Abp.Domain.Entities.EntityNotFoundException(typeof(WayFinder.Calificaciones.Calificacion), id);
+            }
+
+            var isAuthor = entity.UserId == _currentUser.GetId();
+            var isAdmin = await AuthorizationService.IsGrantedAsync(WayFinderPermissions.DeleteCalificacion);
+            
+            // Si no es autor y no tiene permiso de admin, denegar
+            if (!isAuthor && !isAdmin)
+            {
+                throw new AbpAuthorizationException("No tienes permiso para eliminar esta calificación.");
+            }
+            
+            // Realizamos la eliminación física
+            await Repository.DeleteAsync(entity, autoSave: true);
         }
         // --- REQ 5.4: CONSULTAR PROMEDIO ---
         [AllowAnonymous]
@@ -71,9 +90,9 @@ namespace WayFinder.Calificacion
         {
             using (_dataFilter.Disable<Volo.Abp.Auditing.ICreationAuditedObject>())
             {
-                // CAMBIO AQUÍ: Obtenemos el queryable y filtramos manualmente
+                // CAMBIO AQUÍ: Obtenemos el queryable e ignoramos el filtro global de EF Core (IUserOwned) para poder ver las calificaciones de TODOS
                 var queryable = await Repository.GetQueryableAsync();
-                var calificaciones = queryable.Where(c => c.DestinoId == destinoId).ToList();
+                var calificaciones = await queryable.IgnoreQueryFilters().Where(c => c.DestinoId == destinoId).ToListAsync();
 
                 if (!calificaciones.Any())
                 {
@@ -93,14 +112,37 @@ namespace WayFinder.Calificacion
                 // 1. Obtenemos el queryable fresco
                 var queryable = await Repository.GetQueryableAsync();
 
-                // 2. Traemos todo a memoria (ToListAsync requiere "using Microsoft.EntityFrameworkCore;")
-                var todasLasCalificaciones = await queryable.ToListAsync();
+                // 2. Traemos todo a memoria e IGNORAMOS el filtro global IUserOwned para traer todas las calificaciones
+                var todasLasCalificaciones = await queryable.IgnoreQueryFilters().ToListAsync();
 
                 // 3. Filtramos en memoria (donde el tipo Guid ya no es un problema para SQL)
                 var calificaciones = todasLasCalificaciones.Where(c => c.DestinoId == destinoId).ToList();
 
                 return ObjectMapper.Map<List<WayFinder.Calificaciones.Calificacion>, List<CalificacionDto>>(calificaciones);
             }
+        }
+
+        // --- EDITAR CALIFICACION (Solo el autor) ---
+        public override async Task<CalificacionDto> UpdateAsync(Guid id, ActualizarCalificacionDto input)
+        {
+            // 1. Validar autenticación
+            if (!_currentUser.IsAuthenticated)
+                throw new AbpAuthorizationException("Debe estar logueado para editar su calificación.");
+
+            // 2. Obtener la entidad (el filtro IUserOwned asegura que solo el autor la encuentre, pero lo validamos igual por las dudas)
+            var entity = await Repository.GetAsync(id); 
+
+            if (entity.UserId != _currentUser.GetId())
+            {
+                throw new AbpAuthorizationException("No tienes permiso para editar esta calificación.");
+            }
+
+            // 3. Mapear los campos actualizables (Puntaje y Comentario). No mapeamos el DestinoId ni el UserId para que no lo cambien.
+            entity.Puntaje = input.Puntaje;
+            entity.Comentario = input.Comentario;
+            
+            await Repository.UpdateAsync(entity);
+            return ObjectMapper.Map<WayFinder.Calificaciones.Calificacion, CalificacionDto>(entity);
         }
 
         //  Task ICalificacionAppService.CalificarDestinoAsync(CrearCalificacionDto input)

--- a/WayFinder/src/WayFinder.Application/Calificaciones/ICalificacionAppService.cs
+++ b/WayFinder/src/WayFinder.Application/Calificaciones/ICalificacionAppService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using Microsoft.AspNetCore.Authorization;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -13,10 +14,11 @@ namespace WayFinder.Calificacion
          CalificacionDto,
          Guid,
          PagedAndSortedResultRequestDto,
-         CrearCalificacionDto>
+         CrearCalificacionDto,
+         ActualizarCalificacionDto>
     {
-       // Task CalificarDestinoAsync(CrearCalificacionDto input);
-        
+        // Task CalificarDestinoAsync(CrearCalificacionDto input);
+
         Task<double> GetPromedioAsync(Guid destinoId);
 
         Task<List<CalificacionDto>> GetCalificacionesPorDestinoAsync(Guid destinoId);

--- a/WayFinder/src/WayFinder.Domain/Calificaciones/Calificacion.cs
+++ b/WayFinder/src/WayFinder.Domain/Calificaciones/Calificacion.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Volo.Abp.Domain.Entities.Auditing;
 using Volo.Abp.Domain.Entities;
 using WayFinder;
@@ -6,7 +6,8 @@ using WayFinder;
 namespace WayFinder.Calificaciones
 {
     // Implementamos IUserOwned para que ABP sepa que esta entidad "pertenece" a un usuario
-    public class Calificacion : FullAuditedAggregateRoot<Guid>, IUserOwned
+    //public class Calificacion : FullAuditedAggregateRoot<Guid>, IUserOwned
+    public class Calificacion : AuditedAggregateRoot<Guid>, IUserOwned
     {
         public string? Comentario { get; set; }
         public int Puntaje { get; set; } // ej. 1 a 5 estrellas

--- a/WayFinder/src/WayFinder.EntityFrameworkCore/Migrations/20260620135112_InitialFinal.cs
+++ b/WayFinder/src/WayFinder.EntityFrameworkCore/Migrations/20260620135112_InitialFinal.cs
@@ -895,40 +895,40 @@ namespace WayFinder.Migrations
                         onDelete: ReferentialAction.Cascade);
                 });
 
-            migrationBuilder.CreateTable(
-                name: "AppCalificaciones",
-                columns: table => new
-                {
-                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
-                    Comentario = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: true),
-                    Puntaje = table.Column<int>(type: "int", nullable: false),
-                    DestinoId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
-                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
-                    ExtraProperties = table.Column<string>(type: "nvarchar(max)", nullable: false),
-                    ConcurrencyStamp = table.Column<string>(type: "nvarchar(40)", maxLength: 40, nullable: false),
-                    CreationTime = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    CreatorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
-                    LastModificationTime = table.Column<DateTime>(type: "datetime2", nullable: true),
-                    LastModifierId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
-                    IsDeleted = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
-                    DeleterId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
-                    DeletionTime = table.Column<DateTime>(type: "datetime2", nullable: true)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_AppCalificaciones", x => x.Id);
-                    table.ForeignKey(
-                        name: "FK_AppCalificaciones_AbpUsers_UserId",
-                        column: x => x.UserId,
-                        principalTable: "AbpUsers",
-                        principalColumn: "Id");
-                    table.ForeignKey(
-                        name: "FK_AppCalificaciones_AppDestinosTuristicos_DestinoId",
-                        column: x => x.DestinoId,
-                        principalTable: "AppDestinosTuristicos",
-                        principalColumn: "Id",
-                        onDelete: ReferentialAction.Cascade);
-                });
+            //migrationBuilder.CreateTable(
+            //    name: "AppCalificaciones",
+            //    columns: table => new
+            //    {
+            //        Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+            //        Comentario = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: true),
+            //        Puntaje = table.Column<int>(type: "int", nullable: false),
+            //        DestinoId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+            //        UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+            //        ExtraProperties = table.Column<string>(type: "nvarchar(max)", nullable: false),
+            //        ConcurrencyStamp = table.Column<string>(type: "nvarchar(40)", maxLength: 40, nullable: false),
+            //        CreationTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+            //        CreatorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+            //        LastModificationTime = table.Column<DateTime>(type: "datetime2", nullable: true),
+            //        LastModifierId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+            //        IsDeleted = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
+            //        DeleterId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+            //        DeletionTime = table.Column<DateTime>(type: "datetime2", nullable: true)
+            //    },
+            //    constraints: table =>
+            //    {
+            //        table.PrimaryKey("PK_AppCalificaciones", x => x.Id);
+            //        table.ForeignKey(
+            //            name: "FK_AppCalificaciones_AbpUsers_UserId",
+            //            column: x => x.UserId,
+            //            principalTable: "AbpUsers",
+            //            principalColumn: "Id");
+            //        table.ForeignKey(
+            //            name: "FK_AppCalificaciones_AppDestinosTuristicos_DestinoId",
+            //            column: x => x.DestinoId,
+            //            principalTable: "AppDestinosTuristicos",
+            //            principalColumn: "Id",
+            //            onDelete: ReferentialAction.Cascade);
+            //    });
 
             migrationBuilder.CreateTable(
                 name: "OpenIddictAuthorizations",
@@ -1245,15 +1245,15 @@ namespace WayFinder.Migrations
                 table: "AbpUsers",
                 column: "UserName");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_AppCalificaciones_DestinoId",
-                table: "AppCalificaciones",
-                column: "DestinoId");
+            //migrationBuilder.CreateIndex(
+            //    name: "IX_AppCalificaciones_DestinoId",
+            //    table: "AppCalificaciones",
+            //    column: "DestinoId");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_AppCalificaciones_UserId",
-                table: "AppCalificaciones",
-                column: "UserId");
+            //migrationBuilder.CreateIndex(
+            //    name: "IX_AppCalificaciones_UserId",
+            //    table: "AppCalificaciones",
+            //    column: "UserId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_AppDestinosFavoritos_CreatorId_DestinoTuristicoId",

--- a/WayFinder/src/WayFinder.EntityFrameworkCore/Migrations/20260813154901_Nueva-Plantilla-Calificacion.Designer.cs
+++ b/WayFinder/src/WayFinder.EntityFrameworkCore/Migrations/20260813154901_Nueva-Plantilla-Calificacion.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Volo.Abp.EntityFrameworkCore;
 using WayFinder.EntityFrameworkCore;
@@ -12,9 +13,11 @@ using WayFinder.EntityFrameworkCore;
 namespace WayFinder.Migrations
 {
     [DbContext(typeof(WayFinderDbContext))]
-    partial class WayFinderDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260813154901_Nueva-Plantilla-Calificacion")]
+    partial class NuevaPlantillaCalificacion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WayFinder/src/WayFinder.EntityFrameworkCore/Migrations/20260813154901_Nueva-Plantilla-Calificacion.cs
+++ b/WayFinder/src/WayFinder.EntityFrameworkCore/Migrations/20260813154901_Nueva-Plantilla-Calificacion.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WayFinder.Migrations
+{
+    /// <inheritdoc />
+    public partial class NuevaPlantillaCalificacion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AppCalificaciones",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Comentario = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: true),
+                    Puntaje = table.Column<int>(type: "int", nullable: false),
+                    DestinoId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ExtraProperties = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ConcurrencyStamp = table.Column<string>(type: "nvarchar(40)", maxLength: 40, nullable: false),
+                    CreationTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    CreatorId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    LastModificationTime = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    LastModifierId = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AppCalificaciones", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AppCalificaciones_AbpUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AbpUsers",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_AppCalificaciones_AppDestinosTuristicos_DestinoId",
+                        column: x => x.DestinoId,
+                        principalTable: "AppDestinosTuristicos",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppCalificaciones_DestinoId",
+                table: "AppCalificaciones",
+                column: "DestinoId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AppCalificaciones_UserId",
+                table: "AppCalificaciones",
+                column: "UserId");
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AppCalificaciones");
+        }
+    }
+}

--- a/WayFinder/test/WayFinder.Application.Tests/Calificaciones/CalificacionAppService_Test.cs
+++ b/WayFinder/test/WayFinder.Application.Tests/Calificaciones/CalificacionAppService_Test.cs
@@ -1,4 +1,4 @@
-﻿using Autofac.Core;
+using Autofac.Core;
 using Microsoft.AspNetCore.Identity;
 using NSubstitute;
 using Polly.Caching;
@@ -212,7 +212,7 @@ namespace WayFinder.Calificacion
             {
                 // Si tu AppService no tiene un "if (calificacion.UserId != CurrentUser.Id) throw...", 
                 // este test seguirá fallando.
-                await Should.ThrowAsync<Volo.Abp.Domain.Entities.EntityNotFoundException>(async () =>
+                await Should.ThrowAsync<Volo.Abp.Authorization.AbpAuthorizationException>(async () =>
                 {
                     await _calificacionAppService.DeleteAsync(calificacionId);
                 });
@@ -230,6 +230,92 @@ namespace WayFinder.Calificacion
 
             // Assert
             promedio.ShouldBe(0.0);
+        }
+
+        [Fact]
+        // Test para verificar que el autor PUEDE editar su propia calificación
+        public async Task UpdateAsync_Should_Update_Own_Calificacion()
+        {
+            // Arrange
+            var destinoAppService = GetRequiredService<IDestinoTuristicoAppService>();
+            var userManager = GetRequiredService<Volo.Abp.Identity.IdentityUserManager>();
+
+            var destino = await destinoAppService.CreateAsync(new GuardarDestinos
+            {
+                Nombre = "Destino para Editar",
+                Foto = "url_foto_editar",
+                PaisNombre = "Arg",
+                PaisPoblacion = 40,
+                CoordenadasLatitud = -34,
+                CoordenadasLongitud = -58
+            });
+
+            var userId = Guid.NewGuid();
+            await userManager.CreateAsync(new Volo.Abp.Identity.IdentityUser(userId, "usuarioUpdate", "update@wayfinder.com"));
+
+            Guid calificacionId;
+
+            // Act: El usuario crea su propia calificación
+            using (SetCurrentUser(userId))
+            {
+                var input = new CrearCalificacionDto { DestinoId = destino.Id, Puntaje = 5, Comentario = "Original" };
+                var result = await _calificacionAppService.CreateAsync(input);
+                calificacionId = result.Id;
+
+                // Editamos la calificación
+                var updateInput = new ActualizarCalificacionDto { Puntaje = 4, Comentario = "Editado" };
+                var updateResult = await _calificacionAppService.UpdateAsync(calificacionId, updateInput);
+
+                // Assert
+                updateResult.Puntaje.ShouldBe(4);
+                updateResult.Comentario.ShouldBe("Editado");
+            }
+        }
+
+        [Fact]
+        // Test para verificar que NO se puede editar la calificación de otro usuario
+        public async Task UpdateAsync_Should_Throw_If_Not_Author()
+        {
+            // Arrange
+            var destinoAppService = GetRequiredService<IDestinoTuristicoAppService>();
+            var userManager = GetRequiredService<Volo.Abp.Identity.IdentityUserManager>();
+
+            var destino = await destinoAppService.CreateAsync(new GuardarDestinos
+            {
+                Nombre = "Destino Update Other",
+                Foto = "url",
+                PaisNombre = "Arg",
+                PaisPoblacion = 40,
+                CoordenadasLatitud = -34,
+                CoordenadasLongitud = -58
+            });
+
+            var userA = Guid.NewGuid(); 
+            var userB = Guid.NewGuid(); 
+            
+            await userManager.CreateAsync(new Volo.Abp.Identity.IdentityUser(userA, "UserAUpdate", "usera_up@wayfinder.com"));
+            await userManager.CreateAsync(new Volo.Abp.Identity.IdentityUser(userB, "UserBUpdate", "userb_up@wayfinder.com"));
+
+            Guid calificacionId;
+
+            // User A crea la calificación
+            using (SetCurrentUser(userA))
+            {
+                var result = await _calificacionAppService.CreateAsync(new CrearCalificacionDto
+                { DestinoId = destino.Id, Puntaje = 4, Comentario = "Review de User A" });
+                calificacionId = result.Id;
+            }
+
+            // Act & Assert: User B intenta editarla
+            using (SetCurrentUser(userB))
+            {
+                var updateInput = new ActualizarCalificacionDto { Puntaje = 1, Comentario = "Hackeado" };
+                
+                await Should.ThrowAsync<Volo.Abp.Domain.Entities.EntityNotFoundException>(async () =>
+                {
+                    await _calificacionAppService.UpdateAsync(calificacionId, updateInput);
+                });
+            }
         }
         // Método auxiliar para establecer el usuario actual en el contexto de seguridad
         // Esto es crucial para simular la autenticación en las pruebas unitarias.


### PR DESCRIPTION
## 📄 Descripción
Este Pull Request resuelve el Issue #45. Se ha implementado un flujo completo (Full-Stack) para la gestión de las reseñas de destinos, asegurando que los usuarios solo puedan interactuar con sus propios comentarios, mientras se mantiene la capacidad de moderación para administradores.

## ⚙️ Cambios Principales

### Backend (API & Dominio)
* Se cambió la entidad `Calificacion` de `FullAuditedAggregateRoot` a `AuditedAggregateRoot` para habilitar el **borrado físico**.
* Se sobrescribieron los métodos `DeleteAsync` y `UpdateAsync` en `CalificacionAppService`:
  * **Update:** Verifica estrictamente que el usuario autenticado sea el autor. Se introdujo `ActualizarCalificacionDto` para mapear de forma segura solo el puntaje y el comentario.
  * **Delete:** Permite el borrado si eres el autor o si tienes el nuevo permiso de moderador `WayFinder.Calificaciones.Delete`.
* Se incluyó `.IgnoreQueryFilters()` en los métodos de lectura (`GetPromedioAsync`, `GetCalificacionesPorDestinoAsync`) para bypassear temporalmente el filtro `IUserOwned` y calcular promedios globales reales.

### Frontend (Angular)
* Se actualizaron los proxies de ABP (`abp generate-proxy`).
* Se refactorizó `calificaciones.html` y `calificaciones.ts`:
  * Uso del `PermissionService` de `@abp/ng.core` para chequear roles en tiempo real.
  * El botón **Editar** solo es visible para el autor original.
  * El botón **Eliminar** es visible para el autor original **y** para los Administradores.

## 🧪 Cómo probar estos cambios
1. Iniciar sesión con un usuario normal (Usuario A) y crear una calificación.
2. Iniciar sesión con otro usuario (Usuario B) y verificar que los botones de Edición/Borrado **no** aparecen en la calificación del Usuario A.
3. Iniciar sesión con una cuenta de Administrador y verificar que **solo** aparece el botón de Eliminar en las calificaciones ajenas.
4. Ejecutar la suite de tests unitarios del Backend (todos los casos de validación de excepciones han sido actualizados y pasan en verde).

## Horas insumidas: 7 hs.